### PR TITLE
Fix regression in OpenApi::Paths.new

### DIFF
--- a/lib/open_api/callback.rb
+++ b/lib/open_api/callback.rb
@@ -3,7 +3,7 @@ module OpenApi
   class Callback
     extend Forwardable
 
-    def initialize(hash)
+    def initialize(hash = {})
       self.hash = hash.with_indifferent_access
     end
 

--- a/lib/open_api/paths.rb
+++ b/lib/open_api/paths.rb
@@ -4,7 +4,7 @@ module OpenApi
     extend Forwardable
     prepend EquatableAsContent
 
-    def initialize(path_hash)
+    def initialize(path_hash = {})
       self.path_hash = path_hash.with_indifferent_access
     end
 

--- a/spec/open_api/callback_spec.rb
+++ b/spec/open_api/callback_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe OpenApi::Callback do
   it "creates an instance" do
     path_item = double(:path_item)
+    expect(described_class.new).to be_a(described_class)
     expect(
       described_class.new(
         {

--- a/spec/open_api/paths_spec.rb
+++ b/spec/open_api/paths_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe OpenApi::Paths do
   let(:path) { double(:path) }
 
   it "creates instance" do
+    expect(described_class.new).to be_a(described_class)
     expect(described_class.new("/books": path)).to be_a(described_class)
     expect(described_class.new({"/books": path})).to be_a(described_class)
   end


### PR DESCRIPTION
## Why

https://github.com/ngtk/open_api/pull/12 caused a regression where we're no longer able to call `OpenApi::Paths.new` or `OpenApi::Callback.new` without parameters.

## What

Provide a default.